### PR TITLE
Symbols in tuples, load_robots() debugged, CATEGORY, EXCHANGE fields …

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -1,35 +1,51 @@
 from collections import OrderedDict
-
-from api.bitmex.ws import Bitmex
-from api.bybit.ws import Bybit
-
 from typing import Union
+
+from api.bitmex.agent import Agent as BitmexAgent
+from api.bitmex.ws import Bitmex
+from api.bybit.agent import Agent as BybitAgent
+from api.bybit.ws import Bybit
 
 
 class WS(Bitmex, Bybit):
     select_ws = {"Bitmex": Bitmex.start, "Bybit": Bybit.start}
+    agent_get_active_instruments = {
+        "Bitmex": BitmexAgent.get_active_instruments,
+        "Bybit": BybitAgent.get_active_instruments,
+    }
+    agent_get_user = {"Bitmex": BitmexAgent.get_user, "Bybit": BybitAgent.get_user}
+    agent_get_instrument = {
+        "Bitmex": BitmexAgent.get_instrument,
+        "Bybit": BybitAgent.get_instrument,
+    }
+    agent_get_position = {
+        "Bitmex": BitmexAgent.get_position,
+        "Bybit": BybitAgent.get_position,
+    }
 
     def start_ws(self, name) -> None:
         self.select_ws[name](self)
 
-    def get_active_instruments(self) -> OrderedDict:
+    def get_active_instruments(self, name) -> OrderedDict:
         """
         Gets all active instruments from the exchange REST API
         """
 
-        return self.agent.get_active_instruments(self)
-    
-    def get_user(self) -> Union[dict, None]:
+        return self.agent_get_active_instruments[name](self)
+
+    def get_user(self, name) -> Union[dict, None]:
         """
         Gets account info
         """
 
-        return self.agent.get_user(self)
-    
-    def get_instrument_data(self, symbol: tuple) -> OrderedDict:
-        
-        return self.agent.get_instrument_data(self, symbol=symbol)
-    
+        return self.agent_get_user[name](self)
 
-class Websockets:
-    connect = {"Bitmex": WS(), "Bybit": WS()}
+    def get_instrument(self, name, symbol: tuple) -> None:
+
+        return self.agent_get_instrument[name](self, symbol=symbol)
+    
+    def get_position(self, name, symbol: tuple) -> None:
+
+        return self.agent_get_position[name](self, symbol=symbol)
+
+

--- a/api/bitmex/path.py
+++ b/api/bitmex/path.py
@@ -4,6 +4,8 @@ from enum import Enum
 class Listing(str, Enum):
     GET_ACTIVE_INSTRUMENTS = "/instrument/active"
     GET_ACCOUNT_INFO ="/user"
+    GET_INSTRUMENT_DATA = "/instrument?symbol={SYMBOL}"
+    GET_POSITION = "/position?filter=%7B%22symbol%22%3A%22{SYMBOL}%22%7D"
 
 
 

--- a/api/bitmex/ws.py
+++ b/api/bitmex/ws.py
@@ -32,6 +32,7 @@ class Bitmex(Variables):
             self.depth,
         }
         self.name = "Bitmex"
+        self.qwe = 1
         self.agent = Agent
         Setup.variables(self)
         self.currency_divisor = {"XBt": 100000000, "USDt": 1000000, "BMEx": 1000000}

--- a/api/bybit/agent.py
+++ b/api/bybit/agent.py
@@ -1,8 +1,17 @@
 from .http import Send
 from collections import OrderedDict
+from typing import Union
 
 
 class Agent:
     def get_active_instruments(self) -> OrderedDict:
-        pass
-        #Send.request(self)
+        print("---get_active_instruments---")
+
+    def get_user(self) -> Union[dict, None]:
+        print("---get_active_instruments---")
+
+    def get_instrument(self):
+        print("---get_instrument_data---")
+
+    def get_position(self):
+        print("---get_position---")

--- a/api/bybit/ws.py
+++ b/api/bybit/ws.py
@@ -1,9 +1,13 @@
 from api.variables import Variables
+from .agent import Agent
 
 
 class Bybit(Variables):
     def __init__(self):
         pass
-
     def start(self):
-        pass
+        self.agent = Agent
+
+    def get_active_instruments(self, symbol: tuple):
+        
+        return self.agent.get_active_instruments(self, symbol=symbol)

--- a/api/variables.py
+++ b/api/variables.py
@@ -2,13 +2,15 @@ import logging
 from collections import OrderedDict
 from datetime import datetime
 
-import functions as function
+#import functions as function
 from common.variables import Variables as var
 import requests
 
 
+
 class Variables:
     name = ""
+    qwe = 0
     testnet = True
     api_key = ""
     api_secret = ""
@@ -46,12 +48,14 @@ class Variables:
     session.headers.update({"content-type": "application/json"})
     session.headers.update({"accept": "application/json"})
 
-    # HTTP functions
+    '''# HTTP functions
     get_active_instruments = None
     get_user = None
     get_instrument_data = None
+    get_position_data = None'''
 
-    # Exchenge functions
+    # Exchange functions
     transaction = None
     format_price = None
     add_symbol = None
+

--- a/api/websockets.py
+++ b/api/websockets.py
@@ -1,0 +1,4 @@
+from .api import WS
+
+class Websockets:
+    connect = {"Bitmex": WS(), "Bybit": WS()}

--- a/common/init.py
+++ b/common/init.py
@@ -7,11 +7,11 @@ import pymysql
 import pymysql.cursors
 from dotenv import load_dotenv
 
-import functions as function
+#import functions as function
 from bots.variables import Variables as bot
 from common.variables import Variables as var
 from display.variables import Variables as disp
-from ws.init import Variables as ws
+#from ws.init import Variables as ws
 
 load_dotenv()
 db = os.getenv("MYSQL_DATABASE")

--- a/connect.py
+++ b/connect.py
@@ -5,9 +5,8 @@ from collections import OrderedDict
 from datetime import datetime
 from time import sleep
 
-from dotenv import load_dotenv
-
 import algo.init as algo_init
+
 from bots.init import Init as bot_init
 import common.init as common_init
 import display.init as display_init
@@ -15,18 +14,15 @@ from functions import Function
 from bots.variables import Variables as bot
 from common.variables import Variables as var
 from display.variables import Variables as disp
-from api.api import Websockets
+from api.websockets import Websockets
 
 from api.variables import Variables
 
 
 
-load_dotenv()
-
-
 #from API.variables import Variables as API
 
-from api.api import WS
+#from api.api import WS
 
 
 class Loads(Variables):
@@ -34,10 +30,9 @@ class Loads(Variables):
         Loads.clear_params(self)
         bot_init.load_robots(self)
 
-
     def clear_params(self) -> None:
         self.connect_count += 1
-        account = self.get_user()
+        account = self.get_user(self.name)
         if account:
             self.user_id = account["id"]
         else:
@@ -68,6 +63,9 @@ def connection():
     """
     clear_common_params()
     common_init.setup_database_connecion()
+    #ws = Websockets.connect["Bybit"].start_ws("Bybit")
+    #Websockets.connect["Bybit"].get_active_instruments()
+    #exit(0)
     for name, ws in Websockets.connect.items():
         if name in var.exchange_list:
             while ws.logNumFatal: 

--- a/functions.py
+++ b/functions.py
@@ -9,14 +9,16 @@ from typing import Union
 from bots.variables import Variables as bot
 from common.variables import Variables as var
 from display.variables import Variables as disp
-from ws.init import Variables as ws
+#from ws.init import Variables as ws
 
 from api.variables import Variables
 
+from api.api import WS
 
 db = var.env["MYSQL_DATABASE"]
 
-class Function(Variables):
+
+class Function(WS, Variables):
     def calculate(self, symbol: str, price: float, qty: float, rate: int, fund: int) -> dict:
         """
         Calculate sumreal and commission
@@ -36,17 +38,15 @@ class Function(Variables):
 
         return {"sumreal": sumreal, "commiss": commiss, "funding": funding}
     
-    def add_symbol(self, symbol: str) -> None:
+    def add_symbol(self, symbol: tuple) -> None:
         if symbol not in self.full_symbol_list:
             self.full_symbol_list.append(symbol)
             if symbol not in self.instruments:
-                self.instruments = self.get_instrument_data(
-                    symbol=symbol,
-                )
+                self.get_instrument(name=self.name, symbol=symbol)
             Function.rounding(self)
         if symbol not in self.positions:
-            self.positions = self.get_position_data(
-                positions=self.positions, symbol=symbol
+            self.get_position(name=self.name, 
+                symbol=symbol
             )
 
     def rounding(self) -> None:


### PR DESCRIPTION
1. The Bybit exchange contains the same symbol names for different categories, such as “linear”, “inverse” and so on. Accordingly, we had to bring the keys for dictionaries such as 'symbols' or 'positions' into a new format like tuple (SYMBOL, CATEGORY).

2. Loading of data about bots in the file bots/init.py, function load_robots() has been debugged

3. New fields have been added to the database, robots and coins tables: CATEGORY, EXCHANGE. SQL queries are modified accordingly.

4. Bots with RESERVED status received EMI type tuple (SYMBOL, CATEGORY)

5. Loading data via HTTP requests in the api/api.py file in the WS class are implemented as selectors, for example, 'agent_get_user' to select an API by the corresponding name of the exchange.

6. HTTP requests have been debugged for Bitmex: get_active_instruments, get_instrument, get_position, get_user.