### PR TITLE
Missing underlyingToPositionMultiplier field error

### DIFF
--- a/api/bitmex/agent.py
+++ b/api/bitmex/agent.py
@@ -66,7 +66,7 @@ class Agent(Variables):
             minimumTradeAmount = instrument["lotSize"]
             category = "quanto"
         else:  # Linear
-            if instrument["underlyingToPositionMultiplier"]:
+            if "underlyingToPositionMultiplier" in instrument:
                 valueOfOneContract = 1 / instrument["underlyingToPositionMultiplier"]
             elif instrument["underlyingToSettleMultiplier"]:
                 valueOfOneContract = (

--- a/api/bitmex/path.py
+++ b/api/bitmex/path.py
@@ -2,10 +2,10 @@ from enum import Enum
 
 
 class Listing(str, Enum):
-    GET_ACTIVE_INSTRUMENTS = "/instrument/active"
-    GET_ACCOUNT_INFO ="/user"
-    GET_INSTRUMENT_DATA = "/instrument?symbol={SYMBOL}"
-    GET_POSITION = "/position?filter=%7B%22symbol%22%3A%22{SYMBOL}%22%7D"
+    GET_ACTIVE_INSTRUMENTS = "instrument/active"
+    GET_ACCOUNT_INFO ="user"
+    GET_INSTRUMENT_DATA = "instrument?symbol={SYMBOL}"
+    GET_POSITION = "position?filter=%7B%22symbol%22%3A%22{SYMBOL}%22%7D"
     TRADE_BUCKETED = "trade/bucketed?binSize={TIMEFRAME}&count=1000&reverse=\
         false&partial=true&symbol={SYMBOL}&columns=open%2C%20high%2C%20low%2C\
             %20close&startTime={TIME}"

--- a/api/bitmex/ws.py
+++ b/api/bitmex/ws.py
@@ -10,7 +10,7 @@ import websocket
 
 from api.init import Setup
 from api.variables import Variables
-from bots.variables import Variables as bot
+#from bots.variables import Variables as bot
 from ws.api_auth import generate_signature
 from .agent import Agent
 

--- a/bots/init.py
+++ b/bots/init.py
@@ -3,7 +3,6 @@ from typing import Tuple, Union
 
 # from ws.init import Variables as ws
 from api.api import WS
-
 # import functions as function
 from api.init import Variables
 from bots.variables import Variables as bot

--- a/connect.py
+++ b/connect.py
@@ -1,3 +1,4 @@
+
 import os
 import threading
 import time
@@ -8,6 +9,7 @@ from time import sleep
 import algo.init as algo_init
 
 from bots.init import Init as bot_init
+
 import common.init as common_init
 import display.init as display_init
 from functions import Function

--- a/display/init.py
+++ b/display/init.py
@@ -1,11 +1,12 @@
 import tkinter as tk
 
 import connect
-import functions as function
+#import functions as function
 from bots.variables import Variables as bot
 from common.variables import Variables as var
 from display.variables import Variables as disp
-from ws.init import Variables as ws
+
+#from ws.init import Variables as ws
 from datetime import datetime
 
 disp.root.bind("<F3>", lambda event: terminal_reload(event))


### PR DESCRIPTION
Bitmex does not send the underlyingToPositionMultiplier field from instrument endpoint for P_SBFPARDONF25.


In api/bitmex/agent.py:

if instrument["underlyingToPositionMultiplier"]:

replaced with

if "underlyingToPositionMultiplier" in instrument: