### PR TITLE
Removing the 'symbcat' entity.

### DIFF
--- a/bots/init.py
+++ b/bots/init.py
@@ -47,7 +47,7 @@ class Init(WS, Variables):
             emi = robot["EMI"]
             self.robots[emi] = robot
             self.robots[emi]["STATUS"] = "WORK"
-            self.robots[emi]["SYMBCAT"] = (
+            self.robots[emi]["SYMBOL"] = (
                 self.robots[emi]["SYMBOL"],
                 self.robots[emi]["CATEGORY"],
             )
@@ -80,7 +80,7 @@ class Init(WS, Variables):
                     status = "NOT IN LIST"
                 emi = ".".join(symbol)
                 self.robots[emi] = {
-                    "SYMBOL": defunct["SYMBOL"],
+                    "SYMBOL": symbol,
                     "CATEGORY": defunct["CATEGORY"],
                     "EXCHANGE": self.name,
                     "POS": int(defunct["POS"]),
@@ -88,7 +88,6 @@ class Init(WS, Variables):
                     "STATUS": status,
                     "TIMEFR": "None",
                     "CAPITAL": "None",
-                    "SYMBCAT": (defunct["SYMBOL"], defunct["CATEGORY"]),
                 }
 
         # Adding RESERVED robots
@@ -128,19 +127,18 @@ class Init(WS, Variables):
                 emi = ".".join(symbol)
                 self.robots[emi] = {
                     "EMI": emi,
-                    "SYMBOL": symbol[0],
+                    "SYMBOL": symbol,
                     "CATEGORY": symbol[1],
                     "EXCHANGE": self.name,
                     "POS": pos,
                     "STATUS": "RESERVED",
                     "TIMEFR": "None",
                     "CAPITAL": "None",
-                    "SYMBCAT": symbol,
                 }
 
         # Loading all transactions and calculating financial results for each robot
         for emi, val in self.robots.items():
-            Function.add_symbol(self, symbol=self.robots[emi]["SYMBCAT"])
+            Function.add_symbol(self, symbol=self.robots[emi]["SYMBOL"])
             if isinstance(emi, tuple):
                 _emi = emi[0]
             else:
@@ -170,8 +168,8 @@ class Init(WS, Variables):
                         )
             self.robots[emi]["PNL"] = 0
             self.robots[emi]["lotSize"] = (
-                self.instruments[self.robots[emi]["SYMBCAT"]]["lotSize"]
-                / self.instruments[self.robots[emi]["SYMBCAT"]]["myMultiplier"]
+                self.instruments[self.robots[emi]["SYMBOL"]]["lotSize"]
+                / self.instruments[self.robots[emi]["SYMBOL"]]["myMultiplier"]
             )
             if self.robots[emi]["SYMBOL"] not in self.full_symbol_list:
                 self.full_symbol_list.append(self.robots[emi]["SYMBOL"])
@@ -222,7 +220,7 @@ class Init(WS, Variables):
         overwritten.
         """
         self.filename = Function.timeframes_data_filename(
-            self, emi=robot["EMI"], symbol=robot["SYMBCAT"], timefr=robot["TIMEFR"]
+            self, emi=robot["EMI"], symbol=robot["SYMBOL"], timefr=robot["TIMEFR"]
         )
         with open(self.filename, "w"):
             pass
@@ -238,7 +236,7 @@ class Init(WS, Variables):
             self,
             time=time,
             target=target,
-            symbol=robot["SYMBCAT"],
+            symbol=robot["SYMBOL"],
             timeframe=var.timefrs[robot["TIMEFR"]],
         )
         if not res:
@@ -250,7 +248,7 @@ class Init(WS, Variables):
             tm = datetime.strptime(
                 row["timestamp"][0:19], "%Y-%m-%dT%H:%M:%S"
             ) - timedelta(minutes=robot["TIMEFR"])
-            frames[robot["SYMBCAT"]][robot["TIMEFR"]]["data"].append(
+            frames[robot["SYMBOL"]][robot["TIMEFR"]]["data"].append(
                 {
                     "date": (tm.year - 2000) * 10000 + tm.month * 100 + tm.day,
                     "time": tm.hour * 10000 + tm.minute * 100,
@@ -264,13 +262,13 @@ class Init(WS, Variables):
             if num < len(res[:-1]) - 1:
                 Function.save_timeframes_data(
                     self,
-                    frame=frames[robot["SYMBCAT"]][robot["TIMEFR"]]["data"][-1],
+                    frame=frames[robot["SYMBOL"]][robot["TIMEFR"]]["data"][-1],
                 )
-        frames[robot["SYMBCAT"]][robot["TIMEFR"]]["time"] = tm
+        frames[robot["SYMBOL"]][robot["TIMEFR"]]["time"] = tm
 
         message = (
             "Downloaded missing data from the exchange for symbol="
-            + robot["SYMBOL"]
+            + str(robot["SYMBOL"])
             + " TIMEFR="
             + str(robot["TIMEFR"])
         )
@@ -285,7 +283,7 @@ class Init(WS, Variables):
             # expressed in minutes.
             if self.robots[emi]["TIMEFR"] != "None":
                 time = datetime.utcnow()
-                symbol = self.robots[emi]["SYMBCAT"]
+                symbol = self.robots[emi]["SYMBOL"]
                 timefr = self.robots[emi]["TIMEFR"]
                 try:
                     self.frames[symbol]

--- a/common/init.py
+++ b/common/init.py
@@ -175,7 +175,7 @@ class Init(WS, Variables):
                             "STATUS": "NOT DEFINED",
                             "TIMEFR": None,
                             "EMI": emi,
-                            "SYMBOL": val["symbol"][0],
+                            "SYMBOL": val["symbol"],
                             "CATEGORY": val["symbol"][1],
                             "EXCHANGE": self.name,
                             "POS": 0,
@@ -187,7 +187,6 @@ class Init(WS, Variables):
                             ),
                             "PNL": 0,
                             "CAPITAL": None,
-                            "SYMBCAT": val["symbol"]
                         }
                         message = (
                             "Robot EMI="
@@ -201,12 +200,11 @@ class Init(WS, Variables):
                 var.orders[clOrdID]["leavesQty"] = val["leavesQty"]
                 var.orders[clOrdID]["transactTime"] = val["transactTime"]
                 var.orders[clOrdID]["price"] = val["price"]
-                var.orders[clOrdID]["symbol"] = val["symbol"][0]
+                var.orders[clOrdID]["symbol"] = val["symbol"]
                 var.orders[clOrdID]["category"] = val["symbol"][1]
                 var.orders[clOrdID]["exchange"] = self.name
                 var.orders[clOrdID]["side"] = val["side"]
                 var.orders[clOrdID]["orderID"] = val["orderID"]
-                var.orders[clOrdID]["symbcat"] = val["symbol"]
                 Function.orders_display(self, clOrdID=clOrdID)
 
     def initial_ticker_values(self) -> None:

--- a/functions.py
+++ b/functions.py
@@ -182,7 +182,7 @@ class Function(WS, Variables):
                         "STATUS": status,
                         "TIMEFR": None,
                         "EMI": emi,
-                        "SYMBOL": row["symbol"][0],
+                        "SYMBOL": row["symbol"],
                         "CATEGORY": row["symbol"][1],
                         "EXCHANGE": self.name,
                         "POS": 0,
@@ -192,7 +192,6 @@ class Function(WS, Variables):
                         "LTIME": time_struct,
                         "PNL": 0,
                         "CAPITAL": None,
-                        "SYMBCAT": row["symbol"]
                     }
                     message = "Robot EMI=" + str(emi) + ". Adding to 'robots' with STATUS=" + status
                     Function.info_display(self, message)
@@ -365,14 +364,13 @@ class Function(WS, Variables):
                 var.orders[clOrdID] = {
                     "leavesQty": row["leavesQty"],
                     "price": row["price"],
-                    "symbol": row["symbol"][0],
+                    "symbol": row["symbol"],
                     "category": row["symbol"][1],
                     "exchange": self.name,
                     "transactTime": row["transactTime"],
                     "side": row["side"],
                     "emi": row["symbol"],
                     "orderID": row["orderID"],
-                    "symbcat": row["symbol"],
                 }
                 info = "Outside placement: "
             else:
@@ -430,14 +428,13 @@ class Function(WS, Variables):
                     var.orders[clOrdID] = {
                         "leavesQty": row["leavesQty"],
                         "price": row["price"],
-                        "symbol": row["symbol"][0],
+                        "symbol": row["symbol"],
                         "category": row["symbol"][1],
                         "exchange": self.name,
                         "transactTime": str(datetime.utcnow()),
                         "side": row["side"],
                         "emi": _emi,
                         "orderID": row["orderID"],
-                        "symbcat": row["symbol"],
                     }
                 info_p = price
                 info_q = row["orderQty"]
@@ -562,12 +559,12 @@ class Function(WS, Variables):
             time = t[2:4] + t[5:7] + t[8:10] + " " + t[11:23]
             text_insert = (
                 time
-                + gap(val=var.orders[clOrdID]["symbol"], peak=8)
+                + gap(val=".".join(var.orders[clOrdID]["symbol"]), peak=8)
                 + gap(
                     val=Function.format_price(
                         self,
                         number=var.orders[clOrdID]["price"],
-                        symbol=var.orders[clOrdID]["symbcat"],
+                        symbol=var.orders[clOrdID]["symbol"],
                     ),
                     peak=9,
                 )
@@ -575,7 +572,7 @@ class Function(WS, Variables):
                 + " "
                 + Function.volume(
                     self,
-                    qty=var.orders[clOrdID]["leavesQty"], symbol=self.robots[emi]["SYMBCAT"]
+                    qty=var.orders[clOrdID]["leavesQty"], symbol=self.robots[emi]["SYMBOL"]
                 )
                 + "\n"
             )
@@ -933,7 +930,7 @@ class Function(WS, Variables):
         # Update Robots table
 
         for num, emi in enumerate(self.robots):
-            symbol = self.robots[emi]["SYMBCAT"]
+            symbol = self.robots[emi]["SYMBOL"]
             price = Function.close_price(self, symbol=symbol, pos=self.robots[emi]["POS"])
             if price:
                 calc = Function.calculate(
@@ -949,7 +946,7 @@ class Function(WS, Variables):
                     + calc["sumreal"]
                     - self.robots[emi]["COMMISS"]
                 )
-            symbol = self.robots[emi]["SYMBCAT"]
+            symbol = self.robots[emi]["SYMBOL"]
             update_label(table="robots", column=0, row=num + 1, val=emi)
             update_label(table="robots", column=1, row=num + 1, val=symbol)
             update_label(
@@ -1480,8 +1477,8 @@ def handler_orderbook(row_position: int) -> None:
         options = list()
         for emi in ws.robots:
             if (
-                ws.robots[emi]["SYMBCAT"] in ws.symbol_list
-                and ws.robots[emi]["SYMBCAT"] == var.symbol
+                ws.robots[emi]["SYMBOL"] in ws.symbol_list
+                and ws.robots[emi]["SYMBOL"] == var.symbol
             ):
                 options.append(ws.robots[emi]["EMI"])
         option_robots = tk.OptionMenu(frame_robots, emi_number, *options)


### PR DESCRIPTION
Removing the 'symbcat' entity in variables such as 'robots', 'orders'. The 'symbol' entity is always defined as tuple (SYMBOL, CATEGORY).